### PR TITLE
Remove leading whitespace from Python commands so they're copyable

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,8 +46,8 @@ Now that everything's set up, let's animate some drawings! To get started, follo
 
 4. Copy and paste the follow two lines into the interpreter:
 ````python
-    from animated_drawings import render
-    render.start('./examples/config/mvc/interactive_window_example.yaml')
+from animated_drawings import render
+render.start('./examples/config/mvc/interactive_window_example.yaml')
 ````
     
 If everything is installed correctly, an interactive window should appear on your screen. 
@@ -62,8 +62,8 @@ There's a lot happening behind the scenes here. Characters, motions, scenes, and
 Suppose you'd like to save the animation as a video file instead of viewing it directly in a window. Specify a different example config by copying these lines into the Python interpreter:
 
 ````python
-    from animated_drawings import render
-    render.start('./examples/config/mvc/export_mp4_example.yaml')
+from animated_drawings import render
+render.start('./examples/config/mvc/export_mp4_example.yaml')
 ````
 
 Instead of an interactive window, the animation was saved to a file, video.mp4, located in the same directory as your script.
@@ -75,8 +75,8 @@ Instead of an interactive window, the animation was saved to a file, video.mp4, 
 Perhaps you'd like a transparent .gif instead of an .mp4? Copy these lines in the Python interpreter intead:
 
 ````python
-    from animated_drawings import render
-    render.start('./examples/config/mvc/export_gif_example.yaml')
+from animated_drawings import render
+render.start('./examples/config/mvc/export_gif_example.yaml')
 ````
 
 Instead of an interactive window, the animation was saved to a file, video.gif, located in the same directory as your script.
@@ -163,8 +163,8 @@ Multiple characters can be added to a video by specifying multiple entries withi
 To see for yourself, run the following commands from a Python interpreter within the AnimatedDrawings root directory:
 
 ````bash
-    from animated_drawings import render
-    render.start('./examples/config/mvc/multiple_characters_example.yaml')
+from animated_drawings import render
+render.start('./examples/config/mvc/multiple_characters_example.yaml')
 ````
 <img src='./examples/characters/char1/texture.png' height="256" /> <img src='./examples/characters/char2/texture.png' height="256" /> <img src='./media/multiple_characters_example.gif' height="256" />
 
@@ -173,8 +173,8 @@ Suppose you'd like to add a background to the animation. You can do so by specif
 Run the following commands from a Python interpreter within the AnimatedDrawings root directory:
 
 ````python
-    from animated_drawings import render
-    render.start('./examples/config/mvc/background_example.yaml')
+from animated_drawings import render
+render.start('./examples/config/mvc/background_example.yaml')
 ````
 
 <img src='./examples/characters/char4/texture.png' height="256" /> <img src='./examples/characters/char4/background.png' height="256" /> <img src='./media/background_example.gif' height="256" />
@@ -187,8 +187,8 @@ Once you've done that, you should be good to go. The following code and resultin
 Run the following commands from a Python interpreter within the AnimatedDrawings root directory:
 
 ````python
-    from animated_drawings import render
-    render.start('./examples/config/mvc/different_bvh_skeleton_example.yaml')
+from animated_drawings import render
+render.start('./examples/config/mvc/different_bvh_skeleton_example.yaml')
 ````
 
 <img src='./media/different_bvh_skeleton_example.gif' height="256" />


### PR DESCRIPTION
Right now, the Python command instructions cause an error if you naïvely copy paste them into the Python interpreter.

<img width="785" alt="CleanShot 2023-02-15 at 15 24 23@2x" src="https://user-images.githubusercontent.com/425059/219145868-3aab87ac-76c0-4897-9c85-b79673e89665.png">


This is because the code block contains leading whitespace in the Markdown file. Since Python is a whitespace/indent sensitive language, this is an issue.

This PR removes the leading whitespace in the Python codeblocks so that they can easily by copy/pasted into the Python interpreter, without the reader manually having to trim the whitespace themselves.

This also makes it so the copy button copies the right text as well, with no erroneous leading whitespace. 

![CleanShot 2023-02-15 at 15 21 56@2x](https://user-images.githubusercontent.com/425059/219145350-6605fe9e-ce8c-4226-a1cf-9861b7dede9f.png)
