### PR TITLE
Fix crash when exporting videos using OSMesa

### DIFF
--- a/animated_drawings/view/mesa_view.py
+++ b/animated_drawings/view/mesa_view.py
@@ -140,4 +140,5 @@ class MesaView(View):
         GL.glClear(GL.GL_COLOR_BUFFER_BIT | GL.GL_DEPTH_BUFFER_BIT)  # type: ignore
 
     def cleanup(self) -> None:
-        """ No need to destroy a window, as none was created. """
+        """ Destroy the context when it is finished. """
+        osmesa.OSMesaDestroyContext(self.ctx)


### PR DESCRIPTION
Greetings,

The purpose of this PR is to fix the export video crash when using OSMesa.


## Found

I tried exporting two videos in sequence and it crashed (**not in parallel**), 
the config files for the two videos to be exported are the same, `OSMesa: True`.

Test code `test.py`:

```python
import animated_drawings.render

if __name__ == "__main__":
    animated_drawings.render.start('test_mvc.yaml')
    animated_drawings.render.start('test_mvc.yaml')
```

```
root@be35c1400b61:/app# python3.8 test.py 
 Writing video to: /app/output/video.gif
100%|████████████████████████████████████| 33/33 [00:01<00:00, 23.70it/s]
Segmentation fault (dumped)
```

## Solved

I have located the number of lines of code that crashed:
mesa_view.py#114: `osmesa.OSMesaMakeCurrent(self.ctx, self.buffer, GL.GL_UNSIGNED_BYTE, width, height)`

After some tries, I added `osmesa.OSMesaDestroyContext(self.ctx)` to the `cleanup()`, and then it worked. 
But I'm not sure what caused it.

```python
def cleanup(self) -> None:
    osmesa.OSMesaDestroyContext(self.ctx)
```
```
root@be35c1400b61:/app# python3.8 test.py 
 Writing video to: /app/output/video.gif
100%|████████████████████████████████████| 33/33 [00:01<00:00, 21.56it/s]
 Writing video to: /app/output/video.gif
100%|████████████████████████████████████| 33/33 [00:01<00:00, 24.23it/s]
```


--- 

https://github.com/facebookresearch/AnimatedDrawings/blob/1326ae027c7b4e963020188c3b4085fa5242b38e/animated_drawings/view/mesa_view.py#L109-L116



