### PR TITLE
fix: windows size in macOS

### DIFF
--- a/animated_drawings/view/window_view.py
+++ b/animated_drawings/view/window_view.py
@@ -146,7 +146,7 @@ class WindowView(View):
 
     def get_framebuffer_size(self) -> Tuple[int, int]:
         """ Return (width, height) of view's window. """
-        return glfw.get_framebuffer_size(self.win)
+        return glfw.get_window_size(self.win)
 
     def swap_buffers(self) -> None:
         glfw.swap_buffers(self.win)


### PR DESCRIPTION
When a program is running on macOS with an external monitor connected, the values obtained through `glfw.get_framebuffer_size`  will be larger. It is more appropriate to use `glfw.get_window_size` to retrieve the logical size.