### PR TITLE
pin miniconda3 to 24.1.2-0 in torchserve Dockerfile

### DIFF
--- a/torchserve/Dockerfile
+++ b/torchserve/Dockerfile
@@ -1,6 +1,6 @@
 # syntax = docker/dockerfile:1.2
 
-FROM continuumio/miniconda3
+FROM continuumio/miniconda3:24.1.2-0
 
 # install os dependencies
 RUN mkdir -p /usr/share/man/man1


### PR DESCRIPTION
pin miniconda3 to 24.1.2-0 in torchserve Dockerfile

this is ~1mo old as per https://hub.docker.com/r/continuumio/miniconda3/tags

without this, it fails to find torch=2.0.0. if you try bumping that to 2.3.0, then you get a different error on `mim install mmcv-full==1.7.0`

```
➜  torchserve git:(main) docker build -t docker_torchserve .
[+] Building 1.3s (12/25)                                                                                                                                                                                                docker:desktop-linux
 => [internal] load build definition from Dockerfile                                                                                                                                                                                     0.0s
 => => transferring dockerfile: 1.44kB                                                                                                                                                                                                   0.0s
 => resolve image config for docker-image://docker.io/docker/dockerfile:1.2                                                                                                                                                              0.4s
 => CACHED docker-image://docker.io/docker/dockerfile:1.2@sha256:e2a8561e419ab1ba6b2fe6cbdf49fd92b95912df1cf7d313c3e2230a333fdbcc                                                                                                        0.0s
 => [internal] load build definition from Dockerfile                                                                                                                                                                                     0.0s
 => [internal] load .dockerignore                                                                                                                                                                                                        0.0s
 => => transferring context: 2B                                                                                                                                                                                                          0.0s
 => [internal] load metadata for docker.io/continuumio/miniconda3:latest                                                                                                                                                                 0.2s
 => [ 1/19] FROM docker.io/continuumio/miniconda3@sha256:2016f249cdae34692a20d90fdb17432d07cf312992345d0e1e492bc36a12a35b                                                                                                                0.0s
 => [internal] load build context                                                                                                                                                                                                        0.0s
 => => transferring context: 394B                                                                                                                                                                                                        0.0s
 => CACHED [ 2/19] RUN mkdir -p /usr/share/man/man1                                                                                                                                                                                      0.0s
 => CACHED [ 3/19] RUN apt-get update &&     DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends -y     ca-certificates     curl     python3-pip     vim     sudo     default-jre     git     gcc     build-essentia  0.0s
 => CACHED [ 4/19] RUN pip install openmim                                                                                                                                                                                               0.0s
 => ERROR [ 5/19] RUN pip install torch==2.0.0                                                                                                                                                                                           0.5s
------
 > [ 5/19] RUN pip install torch==2.0.0:
0.427 ERROR: Could not find a version that satisfies the requirement torch==2.0.0 (from versions: 2.2.0, 2.2.1, 2.2.2, 2.3.0)
0.427 ERROR: No matching distribution found for torch==2.0.0
------
Dockerfile:22
--------------------
  20 |     # install python dependencies
  21 |     RUN pip install openmim
  22 | >>> RUN pip install torch==2.0.0
  23 |     RUN mim install mmcv-full==1.7.0
  24 |     RUN pip install mmdet==2.27.0
--------------------
ERROR: failed to solve: process "/bin/sh -c pip install torch==2.0.0" did not complete successfully: exit code: 1
➜  torchserve git:(main) vim Dockerfile
➜  torchserve git:(main) ✗ git diff | cat
diff --git a/torchserve/Dockerfile b/torchserve/Dockerfile
index e02861e..e849b16 100644
--- a/torchserve/Dockerfile
+++ b/torchserve/Dockerfile
@@ -19,7 +19,7 @@ RUN apt-get update && \

 # install python dependencies
 RUN pip install openmim
-RUN pip install torch==2.0.0
+RUN pip install torch==2.3.0
 RUN mim install mmcv-full==1.7.0
 RUN pip install mmdet==2.27.0
 RUN pip install torchserve
➜  torchserve git:(main) ✗ docker build -t docker_torchserve .
[+] Building 0.6s (13/25)                                                                                                                                                                                                docker:desktop-linux
 => [internal] load build definition from Dockerfile                                                                                                                                                                                     0.0s
 => => transferring dockerfile: 1.44kB                                                                                                                                                                                                   0.0s
 => resolve image config for docker-image://docker.io/docker/dockerfile:1.2                                                                                                                                                              0.2s
 => CACHED docker-image://docker.io/docker/dockerfile:1.2@sha256:e2a8561e419ab1ba6b2fe6cbdf49fd92b95912df1cf7d313c3e2230a333fdbcc                                                                                                        0.0s
 => [internal] load .dockerignore                                                                                                                                                                                                        0.0s
 => => transferring context: 2B                                                                                                                                                                                                          0.0s
 => [internal] load build definition from Dockerfile                                                                                                                                                                                     0.0s
 => [internal] load metadata for docker.io/continuumio/miniconda3:latest                                                                                                                                                                 0.1s
 => [ 1/19] FROM docker.io/continuumio/miniconda3@sha256:2016f249cdae34692a20d90fdb17432d07cf312992345d0e1e492bc36a12a35b                                                                                                                0.0s
 => [internal] load build context                                                                                                                                                                                                        0.0s
 => => transferring context: 39B                                                                                                                                                                                                         0.0s
 => CACHED [ 2/19] RUN mkdir -p /usr/share/man/man1                                                                                                                                                                                      0.0s
 => CACHED [ 3/19] RUN apt-get update &&     DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends -y     ca-certificates     curl     python3-pip     vim     sudo     default-jre     git     gcc     build-essentia  0.0s
 => CACHED [ 4/19] RUN pip install openmim                                                                                                                                                                                               0.0s
 => CACHED [ 5/19] RUN pip install torch==2.3.0                                                                                                                                                                                          0.0s
 => ERROR [ 6/19] RUN mim install mmcv-full==1.7.0                                                                                                                                                                                       0.2s
------
 > [ 6/19] RUN mim install mmcv-full==1.7.0:
0.170 Traceback (most recent call last):
0.170   File "/opt/conda/bin/mim", line 5, in <module>
0.170     from mim.cli import cli
0.170   File "/opt/conda/lib/python3.12/site-packages/mim/__init__.py", line 10, in <module>
0.170     import setuptools  # noqa: F401
0.170     ^^^^^^^^^^^^^^^^^
0.170   File "/opt/conda/lib/python3.12/site-packages/setuptools/__init__.py", line 16, in <module>
0.171     import setuptools.version
0.171   File "/opt/conda/lib/python3.12/site-packages/setuptools/version.py", line 1, in <module>
0.171     import pkg_resources
0.171   File "/opt/conda/lib/python3.12/site-packages/pkg_resources/__init__.py", line 2172, in <module>
0.172     register_finder(pkgutil.ImpImporter, find_on_path)
0.172                     ^^^^^^^^^^^^^^^^^^^
0.172 AttributeError: module 'pkgutil' has no attribute 'ImpImporter'. Did you mean: 'zipimporter'?
------
Dockerfile:23
--------------------
  21 |     RUN pip install openmim
  22 |     RUN pip install torch==2.3.0
  23 | >>> RUN mim install mmcv-full==1.7.0
  24 |     RUN pip install mmdet==2.27.0
  25 |     RUN pip install torchserve
--------------------
ERROR: failed to solve: process "/bin/sh -c mim install mmcv-full==1.7.0" did not complete successfully: exit code: 1
➜  torchserve git:(main) ✗
```

i do not know enough to fix these dependencies forward, but by pinning `miniconda3` i can get it running

```
.....
=> => writing image sha256:b0e9ae8f288cb152752c0e9970d51dbd542dea4ecd7317d73e96634d516b3be6                                                                                                                                             0.0s
 => => naming to docker.io/library/docker_torchserve                                                                                                                                                                                     0.0s

What's Next?
  View a summary of image vulnerabilities and recommendations → docker scout quickview
➜  torchserve git:(main) ✗ git diff
➜  torchserve git:(main) ✗ git diff | cat
diff --git a/torchserve/Dockerfile b/torchserve/Dockerfile
index e02861e..bb04286 100644
--- a/torchserve/Dockerfile
+++ b/torchserve/Dockerfile
@@ -1,6 +1,6 @@
 # syntax = docker/dockerfile:1.2

-FROM continuumio/miniconda3
+FROM continuumio/miniconda3:24.1.2-0

 # install os dependencies
 RUN mkdir -p /usr/share/man/man1
➜  torchserve git:(main) ✗
```