### PR TITLE
pin numpy to 1.24.4 in torchserve Dockerfile

### DIFF
--- a/torchserve/Dockerfile
+++ b/torchserve/Dockerfile
@@ -32,7 +32,7 @@ RUN python setup.py install
 WORKDIR /
 RUN pip install mmpose==0.29.0
 RUN pip install torchvision==0.15.1  # solve torch version problem
-
+RUN pip install numpy==1.24.4  #solve numpy version problem
 
 # prep torchserve
 RUN mkdir -p /home/torchserve/model-store


### PR DESCRIPTION
Added `RUN pip install numpy==1.24.4  #solve numpy version problem`, which fixes the "Failed to get bounding box, please check if the 'docker_torchserve' is running and healthy <Response: [503]>" issue during the animation. numpy was being reinstalled with wrong version.

torchserve error log:

2024-06-25T21:10:49,070 [INFO ] W-9010-drawn_humanoid_detector_1.0-stdout MODEL_LOG -     return torch.from_numpy(data)
2024-06-25T21:10:49,070 [INFO ] W-9010-drawn_humanoid_detector_1.0-stdout MODEL_LOG -            ^^^^^^^^^^^^^^^^^^^^^^
2024-06-25T21:10:49,070 [INFO ] W-9010-drawn_humanoid_detector_1.0-stdout MODEL_LOG - RuntimeError: Numpy is not available

Adding `RUN pip install numpy==1.24.4` fixes the issue and animation gets successfully created.